### PR TITLE
fix: possible serialization error due to non-transient variable inside serializable class

### DIFF
--- a/api/src/main/java/jakarta/xml/ws/Holder.java
+++ b/api/src/main/java/jakarta/xml/ws/Holder.java
@@ -25,7 +25,7 @@ public final class Holder<T> implements Serializable {
     /**
      * The value contained in the holder.
      */
-    public T value;
+    public transient T value;
 
     /**
      * Creates a new holder with a {@code null} value.


### PR DESCRIPTION
In file: Holder.java, the serializable class Holder contains a non-serializable field. In this case, serialization of the class can lead to a NotSerializableException. iCR suggested to make the fields serializable or transient. To learn more check [CWE 594](https://cwe.mitre.org/data/definitions/594)  and also more explanation and its side effects are briefly explained [here: What Happens When A Serializable Object Contains a Non-Serializable Field?](https://www.openrefactory.com/crash-boom-bang-what-happens-when-a-serializable-object-contains-a-non-serializable-field/#:~:text=scenario%201%3A%20reference%20of%20non-serializable%20object%20inside%20a%20serializable%20object)  

## Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.